### PR TITLE
Changing 16 bit Arduino integers to uint16_t

### DIFF
--- a/software/Arduino/libraries/SFE_BMP180/SFE_BMP180.cpp
+++ b/software/Arduino/libraries/SFE_BMP180/SFE_BMP180.cpp
@@ -134,7 +134,7 @@ char SFE_BMP180::begin()
 }
 
 
-char SFE_BMP180::readInt(char address, int &value)
+char SFE_BMP180::readInt(char address, int16_t &value)
 // Read a signed integer (two bytes) from device
 // address: register to start reading (plus subsequent register)
 // value: external variable to store data (function modifies value)
@@ -144,7 +144,7 @@ char SFE_BMP180::readInt(char address, int &value)
 	data[0] = address;
 	if (readBytes(data,2))
 	{
-		value = (((int)data[0]<<8)|(int)data[1]);
+		value = (((int16_t)data[0]<<8)|(int16_t)data[1]);
 		//if (*value & 0x8000) *value |= 0xFFFF0000; // sign extend if negative
 		return(1);
 	}
@@ -153,7 +153,7 @@ char SFE_BMP180::readInt(char address, int &value)
 }
 
 
-char SFE_BMP180::readUInt(char address, unsigned int &value)
+char SFE_BMP180::readUInt(char address, uint16_t &value)
 // Read an unsigned integer (two bytes) from device
 // address: register to start reading (plus subsequent register)
 // value: external variable to store data (function modifies value)
@@ -163,7 +163,7 @@ char SFE_BMP180::readUInt(char address, unsigned int &value)
 	data[0] = address;
 	if (readBytes(data,2))
 	{
-		value = (((unsigned int)data[0]<<8)|(unsigned int)data[1]);
+		value = (((uint16_t)data[0]<<8)|(uint16_t)data[1]);
 		return(1);
 	}
 	value = 0;

--- a/software/Arduino/libraries/SFE_BMP180/SFE_BMP180.h
+++ b/software/Arduino/libraries/SFE_BMP180/SFE_BMP180.h
@@ -77,13 +77,13 @@ class SFE_BMP180
 
 	private:
 	
-		char readInt(char address, int &value);
+		char readInt(char address, int16_t &value);
 			// read an signed int (16 bits) from a BMP180 register
 			// address: BMP180 register address
 			// value: external signed int for returned value (16 bits)
 			// returns 1 for success, 0 for fail, with result in value
 
-		char readUInt(char address, unsigned int &value);
+		char readUInt(char address, uint16_t &value);
 			// read an unsigned int (16 bits) from a BMP180 register
 			// address: BMP180 register address
 			// value: external unsigned int for returned value (16 bits)
@@ -101,8 +101,8 @@ class SFE_BMP180
 			// length: number of bytes to write
 			// returns 1 for success, 0 for fail
 			
-		int AC1,AC2,AC3,VB1,VB2,MB,MC,MD;
-		unsigned int AC4,AC5,AC6; 
+		int16_t AC1,AC2,AC3,VB1,VB2,MB,MC,MD;
+		uint16_t AC4,AC5,AC6; 
 		double c5,c6,mc,md,x0,x1,x2,y0,y1,y2,p0,p1,p2;
 		char _error;
 };


### PR DESCRIPTION
Changing 16 bit Arduino integers to uint16_t to make it compatible with 32b Teensy integers (and possibly Arduino Due's and other 32b ARM processors)