### PR TITLE
Support for other instances of the library 'Wire.h'

### DIFF
--- a/Libraries/Arduino/examples/BMP180_altitude_example/BMP180_altitude_example.ino
+++ b/Libraries/Arduino/examples/BMP180_altitude_example/BMP180_altitude_example.ino
@@ -53,6 +53,8 @@ V1.1.2 Updates for Arduino 1.6.4 5/2015
 // You will need to create an SFE_BMP180 object, here called "pressure":
 
 SFE_BMP180 pressure;
+// or "&Wire1" to Arduino DUE
+// SFE_BMP180 pressure(&Wire1);
 
 double baseline; // baseline pressure
 
@@ -60,7 +62,7 @@ void setup()
 {
   Serial.begin(9600);
   Serial.println("REBOOT");
-
+  
   // Initialize the sensor (it is important to get calibration values stored on the device).
 
   if (pressure.begin())

--- a/Libraries/Arduino/src/SFE_BMP180.cpp
+++ b/Libraries/Arduino/src/SFE_BMP180.cpp
@@ -44,7 +44,7 @@ char SFE_BMP180::begin()
 	
 	// Start up the Arduino's "wire" (I2C) library:
 	
-// 	twi->begin();
+ 	twi->begin();
 
 	// The BMP180 includes factory calibration data stored on the device.
 	// Each device has different numbers, these must be retrieved and

--- a/Libraries/Arduino/src/SFE_BMP180.cpp
+++ b/Libraries/Arduino/src/SFE_BMP180.cpp
@@ -26,7 +26,15 @@
 SFE_BMP180::SFE_BMP180()
 // Base library type
 {
+	twi = &Wire;
 }
+
+SFE_BMP180::SFE_BMP180(TwoWire *_twi)
+// Base library type
+{
+	twi = _twi;
+}
+
 
 
 char SFE_BMP180::begin()
@@ -36,7 +44,7 @@ char SFE_BMP180::begin()
 	
 	// Start up the Arduino's "wire" (I2C) library:
 	
-	Wire.begin();
+// 	twi->begin();
 
 	// The BMP180 includes factory calibration data stored on the device.
 	// Each device has different numbers, these must be retrieved and
@@ -179,16 +187,16 @@ char SFE_BMP180::readBytes(unsigned char *values, char length)
 {
 	uint8_t x;
 
-	Wire.beginTransmission(BMP180_ADDR);
-	Wire.write(values[0]);
-	_error = Wire.endTransmission();
+	twi->beginTransmission(BMP180_ADDR);
+	twi->write(values[0]);
+	_error = twi->endTransmission();
 	if (_error == 0)
 	{
-		Wire.requestFrom(BMP180_ADDR,length);
-		while(Wire.available() != length) ; // wait until bytes are ready
+		twi->requestFrom(BMP180_ADDR,length);
+		while(twi->available() != length) ; // wait until bytes are ready
 		for(x=0;x<length;x++)
 		{
-			values[x] = Wire.read();
+			values[x] = twi->read();
 		}
 		return(1);
 	}
@@ -201,9 +209,9 @@ char SFE_BMP180::writeBytes(unsigned char *values, char length)
 // values: external array of data to write. Put starting register in values[0].
 // length: number of bytes to write
 {
-	Wire.beginTransmission(BMP180_ADDR);
-	Wire.write(values,length);
-	_error = Wire.endTransmission();
+	twi->beginTransmission(BMP180_ADDR);
+	twi->write(values,length);
+	_error = twi->endTransmission();
 	if (_error == 0)
 		return(1);
 	else

--- a/Libraries/Arduino/src/SFE_BMP180.h
+++ b/Libraries/Arduino/src/SFE_BMP180.h
@@ -26,10 +26,13 @@
 #include "WProgram.h"
 #endif
 
+#include <Wire.h>
+
 class SFE_BMP180
 {
 	public:
 		SFE_BMP180(); // base type
+		SFE_BMP180(TwoWire *_twi); // base type
 
 		char begin();
 			// call pressure.begin() to initialize BMP180 before use
@@ -106,6 +109,8 @@ class SFE_BMP180
 		uint16_t AC4,AC5,AC6; 
 		double c5,c6,mc,md,x0,x1,x2,y0,y1,y2,p0,p1,p2;
 		char _error;
+	
+		TwoWire *twi;
 };
 
 #define BMP180_ADDR 0x77 // 7-bit address


### PR DESCRIPTION
Small changes to support the use of other instances of the 'Wire.h' library, such as 'Wire1' in Arduino DUE