### PR TITLE
Support all i2c buses on Teensy devices

### DIFF
--- a/Libraries/Teensy/README.md
+++ b/Libraries/Teensy/README.md
@@ -5,8 +5,8 @@ This archive contains an Teensy library and example sketch showing how to use th
 
 Info About Update
 -------------------
-* **Wire** library is supported by pointer now, it supports all Arduino and Teensy devices, even those with multiple i2c interfaces. 
-* For using **i2c_t3** library, browse "utilyt" directory and use these files as /src.
+* **Wire** library support using pointer now so BMP180 can be connected to the i2c interface specified by the user. Also, Arduino devices are supported, even those with multiple i2c interfaces. So, same sketches can be run on Arduino and Teensy. (Just wiring is different.)
+* For using **i2c_t3** library, browse "utilyt" directory and use these files as /src. This source code is support just Teensy devices.
 
 Review the example sketch for more information about using.
 

--- a/Libraries/Teensy/README.md
+++ b/Libraries/Teensy/README.md
@@ -5,8 +5,8 @@ This archive contains an Teensy library and example sketch showing how to use th
 
 Info About Update
 -------------------
-* The library is depending **Wire.h** and it supports using of pointers now, so BMP180 can be connected to the i2c interface specified by the user. Also, Arduino devices are supported, even those with multiple i2c interfaces. So, same sketches can be run on Arduino and Teensy. (Just wiring is different.)
-* For using with depend of **i2c_t3.h** library, browse "utilyt" directory and use these files as /src. This source code is support just Teensy devices.
+* The library is depending **Wire.h** and supports specify i2c bus, so BMP180 can be connected to the i2c interface specified by the user.
+* For using with depend of **i2c_t3.h** library, browse "utilyt" directory and use these files as /src.
 
 Review the example sketch for more information about using.
 

--- a/Libraries/Teensy/README.md
+++ b/Libraries/Teensy/README.md
@@ -5,8 +5,8 @@ This archive contains an Teensy library and example sketch showing how to use th
 
 Info About Update
 -------------------
-* **Wire** library support using pointer now so BMP180 can be connected to the i2c interface specified by the user. Also, Arduino devices are supported, even those with multiple i2c interfaces. So, same sketches can be run on Arduino and Teensy. (Just wiring is different.)
-* For using **i2c_t3** library, browse "utilyt" directory and use these files as /src. This source code is support just Teensy devices.
+* The library is depending **Wire.h** and it supports using of pointers now, so BMP180 can be connected to the i2c interface specified by the user. Also, Arduino devices are supported, even those with multiple i2c interfaces. So, same sketches can be run on Arduino and Teensy. (Just wiring is different.)
+* For using with depend of **i2c_t3.h** library, browse "utilyt" directory and use these files as /src. This source code is support just Teensy devices.
 
 Review the example sketch for more information about using.
 

--- a/Libraries/Teensy/README.md
+++ b/Libraries/Teensy/README.md
@@ -1,11 +1,11 @@
 BMP180_Breakout Teensy Library v2.0
 ========================================
 
-This archive contains an Teensy library and example sketch showing how to use this sensor. The library must be installed onto your computer in order for the example code to work correctly.
+This archive contains a Teensy library and an example sketch showing how to use this sensor. The library must be installed onto your computer in order for the example code to work correctly.
 
 Info About Update
 -------------------
-* The library is depending **Wire.h** and supports specify i2c bus, so BMP180 can be connected to the i2c interface specified by the user.
+* Supports all i2c buses, so BMP180 can be connected to the i2c interface specified by the user. (depend of **Wire.h**)
 * For using with depend of **i2c_t3.h** library, browse "utilyt" directory and use these files as /src.
 
 Review the example sketch for more information about using.

--- a/Libraries/Teensy/README.md
+++ b/Libraries/Teensy/README.md
@@ -1,15 +1,22 @@
-BMP180_Breakout Teensy Library
+BMP180_Breakout Teensy Library v2.0
 ========================================
 
 This archive contains an Teensy library and example sketch showing how to use this sensor. The library must be installed onto your computer in order for the example code to work correctly.
 
+Info About Update
+-------------------
+* **Wire** library is supported by pointer now, it supports all Arduino and Teensy devices, even those with multiple i2c interfaces. 
+* For using **i2c_t3** library, browse "utilyt" directory and use these files as /src.
+
+Review the example sketch for more information about using.
+
 Repository Contents
 -------------------
 
-* **/examples** - Example sketches for the library (.ino). Run these from the Arduino IDE. 
+* **/examples** - Example sketches for the library (.ino). Run these from the Arduino IDE.
 * **/src** - Source files for the library (.cpp, .h).
-* **keywords.txt** - Keywords from this library that will be highlighted in the Arduino IDE. 
-* **library.properties** - General library properties for the Teensy package manager. 
+* **keywords.txt** - Keywords from this library that will be highlighted in the Arduino IDE.
+* **library.properties** - General library properties for the Teensy package manager.
 
 Documentation
 --------------
@@ -17,7 +24,7 @@ Documentation
 2. Compress "Teensy" folder with ".zip" extension.
 3. On Arduino IDE, use Include Libraries via ZIP method.
 
-There isn't any documentation yet for using. The Example Code is like a documentation for now.
+There isn't any documentation with details yet for using. The Example Code is like a documentation for now.
 
 
 License Information

--- a/Libraries/Teensy/examples/PressTempAlt/PressTempAlt.ino
+++ b/Libraries/Teensy/examples/PressTempAlt/PressTempAlt.ino
@@ -1,22 +1,37 @@
 /*
- *  BMP180    Teensy
- *  
+ *  BMP180    Teensy 3.5
+ *
+ *  For Wire,
  *  SDA       18
  *  SCL       19
- * 
+ *
+ *  For Wire1,
+ *  SDA       38
+ *  SCL       37
+ *
+ *
+ *  For Wire2,
+ *  SDA       4
+ *  SCL       3
+ *
+ *  For WireX,
+ *  You can see interfaces on the pinouts page: https://www.pjrc.com/teensy/pinout.html*
+ *
+ *
  */
-
 #include <Teensy_BMP180.h>
 double baseline;
 double bmpValues[2]; //0: Temperature, 1:Pressure
-Teensy_BMP180 bmp180;
+Teensy_BMP180 bmp180(&Wire);
+//Teensy_BMP180 bmp180(&Wire1); //If BMP180 is connected to Wire1 bus
+//Teensy_BMP180 bmp180(&Wire2); //If BMP180 is connected to Wire2 bus
 
 void setup() {
   bmp180.begin();
   if(getPressure()){
     baseline=bmpValues[1];
   }
-  
+
 }
 
 void loop() {
@@ -25,7 +40,7 @@ void loop() {
     Serial.print(bmpValues[0]);
     Serial.print(" C | ");
     Serial.print(bmpValues[1]);
-    Serial.print(" mb | ");    
+    Serial.print(" mb | ");
     Serial.print(altVal);
     Serial.println(" cm");
   }

--- a/Libraries/Teensy/src/Teensy_BMP180.cpp
+++ b/Libraries/Teensy/src/Teensy_BMP180.cpp
@@ -4,21 +4,13 @@
 	Bosch BMP180 pressure sensor library for the Teensy microcontroller.
 	unalfaruk.com / A.Faruk UNAL / ahmet@unalfaruk.com || unalfaruk@outlook.com
 	This library depends on SparkFUN BMP180 library and https://roboticboat.uk/Teensy/Teensy36/BMP180.html page.
-	
+
 	---
 */
-
 #include <Teensy_BMP180.h>
-#include <Wire.h>
 #include <stdio.h>
+#include <Wire.h>
 #include <math.h>
-
-
-Teensy_BMP180::Teensy_BMP180()
-// Base library type
-{
-	
-}
 
 
 void Teensy_BMP180::begin()
@@ -28,7 +20,7 @@ void Teensy_BMP180::begin()
 	double c3,c4,b1;
 
 	//Start the wire library
-	Wire.begin();
+	WireSelected->begin();
 
 	//Read the BMP180 factory settings
 	if (readInt(0xAA,AC1) &&
@@ -81,28 +73,28 @@ char Teensy_BMP180::readInt(char registerAddress, int16_t &value)
 	unsigned char byteLow;
 
 	// Begin communication with BMP180
-	Wire.beginTransmission(_i2cAddress);
+	WireSelected->beginTransmission(_i2cAddress);
 
 	// Tell register you want some data
-	Wire.write(registerAddress);
-	  
-	//If false, endTransmission() sends a restart message after transmission. The bus will not be released, 
-	//which prevents another master device from transmitting between messages. This allows one master device 
+	WireSelected->write(registerAddress);
+
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
 	//to send multiple transmissions while in control. The default value is true.
-	int nackCatcher = Wire.endTransmission(false);
+	int nackCatcher = WireSelected->endTransmission(false);
 
 	// Return if we have a connection problem
 	if (nackCatcher != 0) {return 0;}
 
 	// Request 2 bytes from BMP180
-	Wire.requestFrom(_i2cAddress , _TWO_BYTES); 
+	WireSelected->requestFrom(_i2cAddress , _TWO_BYTES);
 
 	// Wait for the bytes to arrive
-	while(Wire.available() < _TWO_BYTES);
+	while(WireSelected->available() < _TWO_BYTES);
 
 	// Read the values
-	byteHigh = Wire.read(); 
-	byteLow = Wire.read();
+	byteHigh = WireSelected->read();
+	byteLow = WireSelected->read();
 
 	value = (((int16_t)byteHigh <<8) + (int16_t)byteLow);
 
@@ -122,28 +114,28 @@ char Teensy_BMP180::readUInt(char registerAddress, uint16_t &value)
 	unsigned char byteLow;
 
 	// Begin communication with BMP180
-	Wire.beginTransmission(_i2cAddress);
+	WireSelected->beginTransmission(_i2cAddress);
 
 	// Tell register you want some data
-	Wire.write(registerAddress);
+	WireSelected->write(registerAddress);
 
-	//If false, endTransmission() sends a restart message after transmission. The bus will not be released, 
-	//which prevents another master device from transmitting between messages. This allows one master device 
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
 	//to send multiple transmissions while in control. The default value is true.
-	int nackCatcher = Wire.endTransmission(false);
+	int nackCatcher = WireSelected->endTransmission(false);
 
 	// Return if we have a connection problem
 	if (nackCatcher != 0) {return 0;}
 
 	// Request 2 bytes from BMP180
-	Wire.requestFrom(_i2cAddress , _TWO_BYTES); 
+	WireSelected->requestFrom(_i2cAddress , _TWO_BYTES);
 
 	// Wait for the bytes to arrive
-	while(Wire.available() < _TWO_BYTES);
+	while(WireSelected->available() < _TWO_BYTES);
 
 	// Read the values
-	byteHigh = Wire.read(); 
-	byteLow = Wire.read();
+	byteHigh = WireSelected->read();
+	byteLow = WireSelected->read();
 
 	value = (((uint16_t)byteHigh <<8) + (uint16_t)byteLow);
 
@@ -159,14 +151,14 @@ char Teensy_BMP180::startTemperature(void)
 // Will return delay in ms to wait, or 0 if I2C error
 {
 	// Begin communication with BMP180
-	Wire.beginTransmission(_i2cAddress);
+	WireSelected->beginTransmission(_i2cAddress);
 
 	// Tell register an instruction
-	Wire.write(_Register_CONTROL);
-	Wire.write(_COMMAND_TEMPERATURE);
+	WireSelected->write(_Register_CONTROL);
+	WireSelected->write(_COMMAND_TEMPERATURE);
 
 	//End transmission and release the bus. The default value is true.
-	int nackCatcher = Wire.endTransmission();
+	int nackCatcher = WireSelected->endTransmission();
 
 	// Return if we have a connection problem
 	if (nackCatcher != 0) {return 0;}
@@ -192,28 +184,28 @@ char Teensy_BMP180::getTemperature(double &T)
 	delay(5);
 
 	// Begin communication with BMP180
-	Wire.beginTransmission(_i2cAddress);
+	WireSelected->beginTransmission(_i2cAddress);
 
 	// Tell register you want some data
-	Wire.write(_Register_RESULT);
+	WireSelected->write(_Register_RESULT);
 
-	//If false, endTransmission() sends a restart message after transmission. The bus will not be released, 
-	//which prevents another master device from transmitting between messages. This allows one master device 
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
 	//to send multiple transmissions while in control. The default value is true.
-	int nackCatcher = Wire.endTransmission(false);
+	int nackCatcher = WireSelected->endTransmission(false);
 
 	// Return if we have a connection problem
 	if (nackCatcher != 0) {return 0;}
 
 	// Request 2 bytes from BMP180
-	Wire.requestFrom(_i2cAddress , _TWO_BYTES); 
+	WireSelected->requestFrom(_i2cAddress , _TWO_BYTES);
 
 	// Wait for the bytes to arrive
-	while(Wire.available() < _TWO_BYTES);
+	while(WireSelected->available() < _TWO_BYTES);
 
 	// Read the values
-	byteHigh = Wire.read(); 
-	byteLow = Wire.read();
+	byteHigh = WireSelected->read();
+	byteLow = WireSelected->read();
 
 	// Calculate the temperature
 	tu = (byteHigh << 8) + byteLow;
@@ -233,14 +225,14 @@ char Teensy_BMP180::startPressure(void)
 // Will return delay in ms to wait, or 0 if I2C error.
 {
 	// Begin a pressure reading.
-	Wire.beginTransmission(_i2cAddress);
+	WireSelected->beginTransmission(_i2cAddress);
 
 	// Tell register an instruction
-	Wire.write(_Register_CONTROL);
-	Wire.write(_COMMAND_PRESSURE);
+	WireSelected->write(_Register_CONTROL);
+	WireSelected->write(_COMMAND_PRESSURE);
 
 	//End transmission and release the bus. The default value is true.
-	int nackCatcher = Wire.endTransmission();
+	int nackCatcher = WireSelected->endTransmission();
 
 	// Return if we have a connection problem
 	if (nackCatcher != 0) {return 0;}
@@ -271,29 +263,29 @@ char Teensy_BMP180::getPressure(double &P, double &T)
 		delay(26);
 
 	// Begin communication with BMP180
-	Wire.beginTransmission(_i2cAddress);
+	WireSelected->beginTransmission(_i2cAddress);
 
 	// Tell register you want some data
-	Wire.write(_Register_RESULT);
+	WireSelected->write(_Register_RESULT);
 
-	//If false, endTransmission() sends a restart message after transmission. The bus will not be released, 
-	//which prevents another master device from transmitting between messages. This allows one master device 
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
 	//to send multiple transmissions while in control. The default value is true.
-	int nackCatcher = Wire.endTransmission();
+	int nackCatcher = WireSelected->endTransmission();
 
 	// Return if we have a connection problem
 	if (nackCatcher != 0) {return 0;}
 
 	// Request 3 bytes from BMP180
-	Wire.requestFrom(_i2cAddress , _THREE_BYTES); 
+	WireSelected->requestFrom(_i2cAddress , _THREE_BYTES);
 
 	// Wait for the bytes to arrive
-	while(Wire.available() < _THREE_BYTES);
+	while(WireSelected->available() < _THREE_BYTES);
 
 	// Read the values
-	byteHigh = Wire.read(); 
-	byteMid = Wire.read();
-	byteLow = Wire.read();
+	byteHigh = WireSelected->read();
+	byteMid = WireSelected->read();
+	byteLow = WireSelected->read();
 
 	// Calculate absolute pressure in mbars.
 	pu = (byteHigh * 256.0) + byteMid + (byteLow/256.0);
@@ -313,6 +305,3 @@ double Teensy_BMP180::altitude(double P, double P0)
 {
 	return(44330.0*(1-pow(P/P0,1/5.255)));
 }
-
-
-

--- a/Libraries/Teensy/src/Teensy_BMP180.h
+++ b/Libraries/Teensy/src/Teensy_BMP180.h
@@ -4,22 +4,25 @@
 	Bosch BMP180 pressure sensor library for the Teensy microcontroller.
 	unalfaruk.com / A.Faruk UNAL / ahmet@unalfaruk.com || unalfaruk@outlook.com
 	This library depends on SparkFUN BMP180 library and https://roboticboat.uk/Teensy/Teensy36/BMP180.html page.
-	
+
 	---
 */
 
 #ifndef Teensy_BMP180_h
 #define Teensy_BMP180_h
-#include <Wire.h>
+#include "Wire.h"
 class Teensy_BMP180
 {
 	public:
-		Teensy_BMP180(); // base type
+
+		Teensy_BMP180(TwoWire *hwWire){
+			WireSelected=hwWire;
+		} // base type
 
 		void begin();
 			// call pressure.begin() to initialize BMP180 before use
 			// returns 1 if success, 0 if failure (bad component or I2C bus shorted?)
-		
+
 		char startTemperature(void);
 			// command BMP180 to start a temperature measurement
 			// returns (number of ms to wait) for success, 0 for fail
@@ -49,7 +52,7 @@ class Teensy_BMP180
 
 
 	private:
-	
+
 		char readInt(char address, int16_t &value);
 			// read an signed int (16 bits) from a BMP180 register
 			// address: BMP180 register address
@@ -62,7 +65,7 @@ class Teensy_BMP180
 			// value: external unsigned int for returned value (16 bits)
 			// returns 1 for success, 0 for fail, with result in value
 
-			
+
 		int16_t AC1,AC2,AC3,VB1,VB2,MB,MC,MD;
 		uint16_t AC4,AC5,AC6;
 
@@ -70,6 +73,8 @@ class Teensy_BMP180
 		double xx0,xx1,xx2;
 		double yy0,yy1,yy2;
 		double p0,p1,p2;
+
+		TwoWire *WireSelected;
 };
 
 //Address of the BMP180 address

--- a/Libraries/Teensy/utilyt/README.md
+++ b/Libraries/Teensy/utilyt/README.md
@@ -1,0 +1,3 @@
+This folder should contain the .cpp and .h files for the library. 
+
+This code supports i2c_t3.h library. You can use this code for Teensy devices. Example sketch is compatible with this source code.

--- a/Libraries/Teensy/utilyt/Teensy_BMP180.cpp
+++ b/Libraries/Teensy/utilyt/Teensy_BMP180.cpp
@@ -1,0 +1,307 @@
+/*
+	SFE_BMP180.cpp
+	---
+	Bosch BMP180 pressure sensor library for the Teensy microcontroller.
+	unalfaruk.com / A.Faruk UNAL / ahmet@unalfaruk.com || unalfaruk@outlook.com
+	This library depends on SparkFUN BMP180 library and https://roboticboat.uk/Teensy/Teensy36/BMP180.html page.
+
+	---
+*/
+#include <Teensy_BMP180.h>
+#include <stdio.h>
+#include <i2c_t3.h>
+#include <math.h>
+
+
+void Teensy_BMP180::begin()
+// Initialize library for subsequent pressure measurements
+{
+	//Initialise the pressure library
+	double c3,c4,b1;
+
+	//Start the wire library
+	WireSelected->begin();
+
+	//Read the BMP180 factory settings
+	if (readInt(0xAA,AC1) &&
+	readInt(0xAC,AC2) &&
+	readInt(0xAE,AC3) &&
+	readUInt(0xB0,AC4) &&
+	readUInt(0xB2,AC5) &&
+	readUInt(0xB4,AC6) &&
+	readInt(0xB6,VB1) &&
+	readInt(0xB8,VB2) &&
+	readInt(0xBA,MB) &&
+	readInt(0xBC,MC) &&
+	readInt(0xBE,MD))
+	{
+	// Calculate calibration polynomials
+
+	c3 = 160.0 * pow(2,-15) * AC3;
+	c4 = pow(10,-3) * pow(2,-15) * AC4;
+	b1 = pow(160,2) * pow(2,-30) * VB1;
+	c5 = (pow(2,-15) / 160) * AC5;
+	c6 = AC6;
+
+	mc = (pow(2,11) / pow(160,2)) * MC;
+	md = MD / 160.0;
+
+	xx0 = AC1;
+	xx1 = 160.0 * pow(2,-13) * AC2;
+	xx2 = pow(160,2) * pow(2,-25) * VB2;
+
+	yy0 = c4 * pow(2,15);
+	yy1 = c4 * c3;
+	yy2 = c4 * b1;
+
+	p0 = (3791.0 - 8.0) / 1600.0;
+	p1 = 1.0 - 7357.0 * pow(2,-20);
+	p2 = 3038.0 * 100.0 * pow(2,-36);
+
+	}
+}
+
+
+char Teensy_BMP180::readInt(char registerAddress, int16_t &value)
+// Read a signed integer (two bytes) from device
+// address: register to start reading (plus subsequent register)
+// value: external variable to store data (function modifies value)
+{
+	// Read a signed integer from device
+
+	unsigned char byteHigh;
+	unsigned char byteLow;
+
+	// Begin communication with BMP180
+	WireSelected->beginTransmission(_i2cAddress);
+
+	// Tell register you want some data
+	WireSelected->write(registerAddress);
+
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
+	//to send multiple transmissions while in control. The default value is true.
+	int nackCatcher = WireSelected->endTransmission(false);
+
+	// Return if we have a connection problem
+	if (nackCatcher != 0) {return 0;}
+
+	// Request 2 bytes from BMP180
+	WireSelected->requestFrom(_i2cAddress , _TWO_BYTES);
+
+	// Wait for the bytes to arrive
+	while(WireSelected->available() < _TWO_BYTES);
+
+	// Read the values
+	byteHigh = WireSelected->read();
+	byteLow = WireSelected->read();
+
+	value = (((int16_t)byteHigh <<8) + (int16_t)byteLow);
+
+	// Return true as ok
+	return(1);
+}
+
+
+char Teensy_BMP180::readUInt(char registerAddress, uint16_t &value)
+// Read an unsigned integer (two bytes) from device
+// address: register to start reading (plus subsequent register)
+// value: external variable to store data (function modifies value)
+{
+	// Read an unsigned integer from device
+
+	unsigned char byteHigh;
+	unsigned char byteLow;
+
+	// Begin communication with BMP180
+	WireSelected->beginTransmission(_i2cAddress);
+
+	// Tell register you want some data
+	WireSelected->write(registerAddress);
+
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
+	//to send multiple transmissions while in control. The default value is true.
+	int nackCatcher = WireSelected->endTransmission(false);
+
+	// Return if we have a connection problem
+	if (nackCatcher != 0) {return 0;}
+
+	// Request 2 bytes from BMP180
+	WireSelected->requestFrom(_i2cAddress , _TWO_BYTES);
+
+	// Wait for the bytes to arrive
+	while(WireSelected->available() < _TWO_BYTES);
+
+	// Read the values
+	byteHigh = WireSelected->read();
+	byteLow = WireSelected->read();
+
+	value = (((uint16_t)byteHigh <<8) + (uint16_t)byteLow);
+
+	// Return true as ok
+	return(1);
+}
+
+
+
+
+char Teensy_BMP180::startTemperature(void)
+// Begin a temperature reading.
+// Will return delay in ms to wait, or 0 if I2C error
+{
+	// Begin communication with BMP180
+	WireSelected->beginTransmission(_i2cAddress);
+
+	// Tell register an instruction
+	WireSelected->write(_Register_CONTROL);
+	WireSelected->write(_COMMAND_TEMPERATURE);
+
+	//End transmission and release the bus. The default value is true.
+	int nackCatcher = WireSelected->endTransmission();
+
+	// Return if we have a connection problem
+	if (nackCatcher != 0) {return 0;}
+
+	// Return true as ok
+	return(1);
+
+}
+
+
+char Teensy_BMP180::getTemperature(double &T)
+// Retrieve a previously-started temperature reading.
+// Requires begin() to be called once prior to retrieve calibration parameters.
+// Requires startTemperature() to have been called prior and sufficient time elapsed.
+// T: external variable to hold result.
+// Returns 1 if successful, 0 if I2C error.
+{
+	unsigned char byteHigh;
+	unsigned char byteLow;
+	double tu, a;
+
+	// Wait for the measurement to complete:
+	delay(5);
+
+	// Begin communication with BMP180
+	WireSelected->beginTransmission(_i2cAddress);
+
+	// Tell register you want some data
+	WireSelected->write(_Register_RESULT);
+
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
+	//to send multiple transmissions while in control. The default value is true.
+	int nackCatcher = WireSelected->endTransmission(false);
+
+	// Return if we have a connection problem
+	if (nackCatcher != 0) {return 0;}
+
+	// Request 2 bytes from BMP180
+	WireSelected->requestFrom(_i2cAddress , _TWO_BYTES);
+
+	// Wait for the bytes to arrive
+	while(WireSelected->available() < _TWO_BYTES);
+
+	// Read the values
+	byteHigh = WireSelected->read();
+	byteLow = WireSelected->read();
+
+	// Calculate the temperature
+	tu = (byteHigh << 8) + byteLow;
+	a = c5 * (tu - c6);
+	T = a + (mc / (a + md));
+
+	// Return true as ok
+	return(1);
+}
+
+
+//char Teensy_BMP180::startPressure(char oversampling)
+char Teensy_BMP180::startPressure(void)
+
+// Begin a pressure reading.
+// Oversampling: 0 to 3, higher numbers are slower, higher-res outputs.
+// Will return delay in ms to wait, or 0 if I2C error.
+{
+	// Begin a pressure reading.
+	WireSelected->beginTransmission(_i2cAddress);
+
+	// Tell register an instruction
+	WireSelected->write(_Register_CONTROL);
+	WireSelected->write(_COMMAND_PRESSURE);
+
+	//End transmission and release the bus. The default value is true.
+	int nackCatcher = WireSelected->endTransmission();
+
+	// Return if we have a connection problem
+	if (nackCatcher != 0) {return 0;}
+
+	// Return true as ok
+	return(1);
+}
+
+
+char Teensy_BMP180::getPressure(double &P, double &T)
+// Retrieve a previously started pressure reading, calculate abolute pressure in mbars.
+// Requires begin() to be called once prior to retrieve calibration parameters.
+// Requires startPressure() to have been called prior and sufficient time elapsed.
+// Requires recent temperature reading to accurately calculate pressure.
+
+// P: external variable to hold pressure.
+// T: previously-calculated temperature.
+// Returns 1 for success, 0 for I2C error.
+
+// Note that calculated pressure value is absolute mbars, to compensate for altitude call sealevel().
+{
+	unsigned char byteHigh;
+	unsigned char byteMid;
+	unsigned char byteLow;
+	double pu,s,x,y,z;
+
+	// Wait for the measurement to complete:
+		delay(26);
+
+	// Begin communication with BMP180
+	WireSelected->beginTransmission(_i2cAddress);
+
+	// Tell register you want some data
+	WireSelected->write(_Register_RESULT);
+
+	//If false, endTransmission() sends a restart message after transmission. The bus will not be released,
+	//which prevents another master device from transmitting between messages. This allows one master device
+	//to send multiple transmissions while in control. The default value is true.
+	int nackCatcher = WireSelected->endTransmission();
+
+	// Return if we have a connection problem
+	if (nackCatcher != 0) {return 0;}
+
+	// Request 3 bytes from BMP180
+	WireSelected->requestFrom(_i2cAddress , _THREE_BYTES);
+
+	// Wait for the bytes to arrive
+	while(WireSelected->available() < _THREE_BYTES);
+
+	// Read the values
+	byteHigh = WireSelected->read();
+	byteMid = WireSelected->read();
+	byteLow = WireSelected->read();
+
+	// Calculate absolute pressure in mbars.
+	pu = (byteHigh * 256.0) + byteMid + (byteLow/256.0);
+
+	s = T - 25.0;
+	x = (xx2 * pow(s,2)) + (xx1 * s) + xx0;
+	y = (yy2 * pow(s,2)) + (yy1 * s) + yy0;
+	z = (pu - x) / y;
+	P = (p2 * pow(z,2)) + (p1 * z) + p0;
+
+	return(1);
+}
+
+double Teensy_BMP180::altitude(double P, double P0)
+// Given a pressure measurement P (mb) and the pressure at a baseline P0 (mb),
+// return altitude (meters) above baseline.
+{
+	return(44330.0*(1-pow(P/P0,1/5.255)));
+}

--- a/Libraries/Teensy/utilyt/Teensy_BMP180.h
+++ b/Libraries/Teensy/utilyt/Teensy_BMP180.h
@@ -1,0 +1,97 @@
+/*
+	SFE_BMP180.h
+	---
+	Bosch BMP180 pressure sensor library for the Teensy microcontroller.
+	unalfaruk.com / A.Faruk UNAL / ahmet@unalfaruk.com || unalfaruk@outlook.com
+	This library depends on SparkFUN BMP180 library and https://roboticboat.uk/Teensy/Teensy36/BMP180.html page.
+
+	---
+*/
+
+#ifndef Teensy_BMP180_h
+#define Teensy_BMP180_h
+
+#include "i2c_t3.h"
+
+class Teensy_BMP180
+{
+	public:
+
+		Teensy_BMP180(i2c_t3 *hwWire){
+			WireSelected=hwWire;
+		} // base type
+
+		void begin();
+			// call pressure.begin() to initialize BMP180 before use
+			// returns 1 if success, 0 if failure (bad component or I2C bus shorted?)
+
+		char startTemperature(void);
+			// command BMP180 to start a temperature measurement
+			// returns (number of ms to wait) for success, 0 for fail
+
+		char getTemperature(double &T);
+			// return temperature measurement from previous startTemperature command
+			// places returned value in T variable (deg C)
+			// returns 1 for success, 0 for fail
+
+		char startPressure(void);
+			// command BMP180 to start a pressure measurement
+			// oversampling: 0 - 3 for oversampling value
+			// returns (number of ms to wait) for success, 0 for fail
+
+		char getPressure(double &P, double &T);
+			// return absolute pressure measurement from previous startPressure command
+			// note: requires previous temperature measurement in variable T
+			// places returned value in P variable (mbar)
+			// returns 1 for success, 0 for fail
+
+		double altitude(double P, double P0);
+			// convert absolute pressure to altitude (given baseline pressure; sea-level, runway, etc.)
+			// P: absolute pressure (mbar)
+			// P0: fixed baseline pressure (mbar)
+			// returns signed altitude in meters
+
+
+
+	private:
+
+		char readInt(char address, int16_t &value);
+			// read an signed int (16 bits) from a BMP180 register
+			// address: BMP180 register address
+			// value: external signed int for returned value (16 bits)
+			// returns 1 for success, 0 for fail, with result in value
+
+		char readUInt(char address, uint16_t &value);
+			// read an unsigned int (16 bits) from a BMP180 register
+			// address: BMP180 register address
+			// value: external unsigned int for returned value (16 bits)
+			// returns 1 for success, 0 for fail, with result in value
+
+
+		int16_t AC1,AC2,AC3,VB1,VB2,MB,MC,MD;
+		uint16_t AC4,AC5,AC6;
+
+		double c5,c6,mc,md;
+		double xx0,xx1,xx2;
+		double yy0,yy1,yy2;
+		double p0,p1,p2;
+
+		i2c_t3 *WireSelected;
+};
+
+//Address of the BMP180 address
+#define _i2cAddress 0x77
+
+//Registers
+#define _Register_CONTROL 0xF4
+#define _Register_RESULT 0xF6
+
+//Commands
+#define _COMMAND_TEMPERATURE 0x2E
+#define _COMMAND_PRESSURE 0xF4
+
+#define _ONE_BYTE 1
+#define _TWO_BYTES 2
+#define _THREE_BYTES 3
+
+#endif


### PR DESCRIPTION
Thanks to this update, users can determine any i2c buses which they want to connect BMP180.

Teensy devices have more than one i2c buses, but the previous library for Teensy devices just had been supporting only one i2c bus and this bus was determined by library. For using other i2c buses, users had to edit library.

But now! Users can determine in the sketch, any i2c bus which they want to use. Just determine by using Wire0, Wire1, Wire2 etc.

There are /src and /utilyt directories, these libraries do the same task. There is a just difference about dependency;
/src is depend on Wire.h library.
/utilyt is depend on i2c_t3.h library.